### PR TITLE
Two crash fixes

### DIFF
--- a/src/editor/C4ConsoleQtDefinitionListViewer.cpp
+++ b/src/editor/C4ConsoleQtDefinitionListViewer.cpp
@@ -108,6 +108,7 @@ void C4ConsoleQtDefinitionListModel::ReInit()
 	{
 		std::unique_ptr<DefListNode> tmp(new_root->items[0].release());
 		root.reset(tmp.release());
+		new_root = root.get();
 	}
 	// Sort everything by display name (recursively)
 	root->SortByName();

--- a/src/graphics/C4DrawGLCtx.cpp
+++ b/src/graphics/C4DrawGLCtx.cpp
@@ -681,6 +681,8 @@ bool CStdGLCtxQt::Init(C4Window *window, C4AbstractApp *app)
 		surface = new QOffscreenSurface();
 		surface->create();
 		context = new QOpenGLContext();
+		QOpenGLContext* share_context = QOpenGLContext::globalShareContext();
+		if (share_context) context->setShareContext(share_context);
 		if (!context->create())
 			return false;
 


### PR DESCRIPTION
One unrelated to OpenGL, I think, and the other fixes a crash in QOpenGLWidget::paintGL, by allowing it to share objects with the context constructed at Clonk initialization.
