### PR TITLE
FoW rendering: reset to previous framebuffer instead of default one

### DIFF
--- a/src/landscape/fow/C4FoWRegion.cpp
+++ b/src/landscape/fow/C4FoWRegion.cpp
@@ -47,7 +47,7 @@ C4FoWRegion::~C4FoWRegion()
 #endif
 }
 
-bool C4FoWRegion::BindFramebuf()
+bool C4FoWRegion::BindFramebuf(GLuint prev_fb)
 {
 #ifndef USE_CONSOLE
 	// Flip texture
@@ -149,7 +149,7 @@ bool C4FoWRegion::BindFramebuf()
 	if (status1 != GL_FRAMEBUFFER_COMPLETE ||
 	   (pBackSurface && status2 != GL_FRAMEBUFFER_COMPLETE))
 	{
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		glBindFramebuffer(GL_FRAMEBUFFER, prev_fb);
 		return false;
 	}
 #endif
@@ -188,6 +188,9 @@ void C4FoWRegion::Update(C4Rect r, const FLOAT_RECT& vp)
 bool C4FoWRegion::Render(const C4TargetFacet *pOnScreen)
 {
 #ifndef USE_CONSOLE
+	GLint prev_fb;
+	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fb);
+
 	// Update FoW at interesting location
 	pFoW->Update(Region, pPlayer);
 
@@ -205,7 +208,7 @@ bool C4FoWRegion::Render(const C4TargetFacet *pOnScreen)
 
 	// Create & bind the frame buffer
 	pDraw->StorePrimaryClipper();
-	if(!BindFramebuf())
+	if(!BindFramebuf(prev_fb))
 	{
 		pDraw->RestorePrimaryClipper();
 		return false;
@@ -328,7 +331,7 @@ bool C4FoWRegion::Render(const C4TargetFacet *pOnScreen)
 	}
 
 	// Done!
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glBindFramebuffer(GL_FRAMEBUFFER, prev_fb);
 	pDraw->RestorePrimaryClipper();
 
 	OldRegion = Region;

--- a/src/landscape/fow/C4FoWRegion.h
+++ b/src/landscape/fow/C4FoWRegion.h
@@ -59,7 +59,7 @@ public:
 	// Fills a 2x3 matrix to transform fragment coordinates to light texture coordinates
 	void GetFragTransform(const C4Rect& clipRect, const C4Rect& outRect, float lightTransform[6]) const;
 private:
-	bool BindFramebuf();
+	bool BindFramebuf(GLuint prev_fb);
 
 };
 


### PR DESCRIPTION
The QOpenGLWidget is set up to render into a custom framebuffer, and by
resetting to render into the default framebuffer, we don't draw anything in
the buffer that is actually going to be displayed by the widget.
